### PR TITLE
fix: Add error handling to usePresentationAPI

### DIFF
--- a/src/lib/composables/apis/usePresentationAPI.ts
+++ b/src/lib/composables/apis/usePresentationAPI.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 
@@ -11,6 +10,7 @@ export default () => {
     return availability.value;
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const setPresentationConnection = (connection: any | undefined) => {
     if (connection !== undefined) {
       // Set the new connection and save the presentation ID
@@ -42,6 +42,7 @@ export default () => {
   };
 
   const addPresentationConnection = (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     conn: any,
     callback: (message: MessageEvent) => void
   ) => {
@@ -64,9 +65,9 @@ export default () => {
 
       // Return the connection
       return connection;
-    } catch {
+    } catch (e: Error) {
       // Otherwise, the user canceled the selection dialog or no screens were found.
-      console.error("[Presentation] Failed to start...");
+      throw new Error(`[Presentation] Failed to start with reason: ${e}`);
     }
   };
 
@@ -85,14 +86,16 @@ export default () => {
       return connection;
     } catch {
       // No connection found for presUrl and presId, or an error occurred.
-      console.error("[Presentation] Failed to start...");
+      throw new Error(`[Presentation] Failed to reconnect with reason: ${e}`);
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const closePresentation = (connection: any | undefined) => {
     connection?.close();
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const terminatePresentation = (connection: any | undefined) => {
     connection?.terminate();
   };

--- a/src/lib/composables/usePresentation.ts
+++ b/src/lib/composables/usePresentation.ts
@@ -17,6 +17,7 @@ export default () => {
     initialisePresentationReceiver,
   } = usePresentationAPI();
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [connection, setConnection] = createSignal<any | undefined>(undefined);
   const [isConnected, setIsConnected] = createSignal<boolean>(false);
   const [isVisible, setIsVisible] = createSignal<boolean>(true);


### PR DESCRIPTION
When the startPresentation and reconnectPresentation methods fail, they were only logging an error. This
would cause the calling function to continue execution and eventually, set the isConnected state to 'true'
even though it failed. This fix addresses that by throwing the relevant errors, thus preventing illegal
setting of the isConnected signal.

Closes #120

# Summary

> [!TIP]
> Gives the reviewer some context about the work why this change is being made, and WHY you are doing this. This field goes more into the product perspective.

## Changelog

> [!TIP]
> This is where it becomes technical. Here is where you can focus more on your solution's engineering side. Include details about the functionality being added or modified and any refactoring or enhancements to existing code.

- [ ] Changes outside the codebase (e.g. env variables, database, external service, etc...)? If yes, could you provide context?

---

# Testing

- [ ] Unit tested. If not, why?

- [ ] Integration tested. If not, why?

## Screenshots

---

## Additional notes

> [!TIP]
> Links to relevant documentation or articles.
