### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -8,6 +8,9 @@ on:
       - completed
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/briankiragu/projectr/security/code-scanning/1](https://github.com/briankiragu/projectr/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default.  
Best single fix without changing functionality: define root-level permissions with the minimal required scope.

In `.github/workflows/playwright.yml`, insert:

- `permissions:`
- `contents: read`

directly after the `on:` trigger section (before `jobs:`), so it applies to all jobs in this workflow. This satisfies CodeQL and documents intended least-privilege access while preserving current behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
